### PR TITLE
Optimize default Nmap Tracker scan options

### DIFF
--- a/homeassistant/components/nmap_tracker/const.py
+++ b/homeassistant/components/nmap_tracker/const.py
@@ -13,6 +13,6 @@ NMAP_TRACKED_DEVICES: Final = "nmap_tracked_devices"
 # Interval in minutes to exclude devices from a scan while they are home
 CONF_HOME_INTERVAL: Final = "home_interval"
 CONF_OPTIONS: Final = "scan_options"
-DEFAULT_OPTIONS: Final = "-F -T4 --min-rate 10 --host-timeout 5s"
+DEFAULT_OPTIONS: Final = "-n -sn -PR -T4 --min-rate 10 --host-timeout 5s"
 
 TRACKER_SCAN_INTERVAL: Final = 120

--- a/tests/components/nmap_tracker/test_config_flow.py
+++ b/tests/components/nmap_tracker/test_config_flow.py
@@ -213,7 +213,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         CONF_HOSTS: "192.168.1.0/24",
         CONF_CONSIDER_HOME: 180,
         CONF_SCAN_INTERVAL: 120,
-        CONF_OPTIONS: "-F -T4 --min-rate 10 --host-timeout 5s",
+        CONF_OPTIONS: "-n -sn -PR -T4 --min-rate 10 --host-timeout 5s",
     }
 
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Updated the default scan options of Nmap Tracker integration for the purpose of device tracking.

#### Removed:
- Port scanning of 100 common ports **(-F)**: Unnecessarily wastes time when the goal is only to check which hosts are online.
#### Added:
- Skip DNS lookups **(-n)**: Avoid delays from reverse DNS queries.
- Skip port scanning **(-sn)**: Only check host availability, which is exactly what device tracker needs.
- Use ARP ping **(-PR)**: Fast detection of hosts on LAN, regardless of blocked ICMP.
#### Benchmarking:
Direct comparison of best of 3 runs on my home network shows over x30 improvement in time.
- Before:
```
sudo nmap -F -T4 --min-rate 10 --host-timeout 5s 192.168.1.0/24
Starting Nmap 7.97 ( https://nmap.org ) at 2025-09-26 13:32 +0100
...
Nmap done: 256 IP addresses (21 hosts up) scanned in 102.71 seconds
```
- After:
```
sudo nmap -n -sn -PR -T4 --min-rate 10 --host-timeout 5s 192.168.1.0/24
Starting Nmap 7.97 ( https://nmap.org ) at 2025-09-26 13:41 +0100
...
Nmap done: 256 IP addresses (21 hosts up) scanned in 2.83 seconds
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
